### PR TITLE
Add Missing Expectations from The Basics 

### DIFF
--- a/src/Expectations/Authentication.php
+++ b/src/Expectations/Authentication.php
@@ -27,3 +27,9 @@ expect()->extend(
     fn (): ArchExpectation => // @phpstan-ignore-next-line
     $this->toUse('Saloon\Http\Auth\HeaderAuthenticator')
 );
+
+expect()->extend(
+    'toUseQueryAuthentication',
+    fn (): ArchExpectation => // @phpstan-ignore-next-line
+    $this->toUse('Saloon\Http\Auth\QueryAuthenticator')
+);

--- a/src/Expectations/Connector.php
+++ b/src/Expectations/Connector.php
@@ -9,3 +9,39 @@ expect()->extend(
     fn (): ArchExpectation => // @phpstan-ignore-next-line
     $this->toExtend('Saloon\Http\Connector')
 );
+
+expect()->extend(
+    'toHaveDefaultHeaders',
+    fn (): ArchExpectation => // @phpstan-ignore-next-line
+    $this->toHaveMethod('defaultHeaders')
+);
+
+expect()->extend(
+    'toHaveDefaultConfig',
+    fn (): ArchExpectation => // @phpstan-ignore-next-line
+    $this->toHaveMethod('defaultConfig')
+);
+
+expect()->extend(
+    'toHaveBaseUrl',
+    fn (): ArchExpectation => // @phpstan-ignore-next-line
+    $this->toHaveMethod('resolveBaseUrl')
+);
+
+expect()->extend(
+    'toUseCustomResponse',
+    fn (): ArchExpectation => // @phpstan-ignore-next-line
+    $this->toHaveMethod('resolveResponseClass')
+);
+
+expect()->extend(
+    'toHaveCustomFailureDetection',
+    fn (): ArchExpectation => // @phpstan-ignore-next-line
+    $this->toHaveMethod('hasRequestFailed')
+);
+
+expect()->extend(
+    'toHaveCustomException',
+    fn (): ArchExpectation => // @phpstan-ignore-next-line
+    $this->toHaveMethod('getRequestException')
+);

--- a/src/Expectations/Request.php
+++ b/src/Expectations/Request.php
@@ -131,3 +131,15 @@ expect()->extend(
     $this->toImplement('Saloon\Contracts\Body\HasBody')
         ->toUse('Saloon\Traits\Body\HasStreamBody')
 );
+
+expect()->extend(
+    'toHaveDefaultQuery',
+    fn (): ArchExpectation => // @phpstan-ignore-next-line
+    $this->toHaveMethod('defaultQuery')
+);
+
+expect()->extend(
+    'toHaveDefaultBody',
+    fn (): ArchExpectation => // @phpstan-ignore-next-line
+    $this->toHaveMethod('defaultBody')
+);

--- a/tests/Feature/AuthenticationTest.php
+++ b/tests/Feature/AuthenticationTest.php
@@ -27,3 +27,8 @@ it('checks that a class uses multiple authentication methods', function () {
         ->toUseCertificateAuthentication()
         ->toUseTokenAuthentication();
 });
+
+it('checks that a class uses query authentication', function () {
+    expect('Tests\Fixtures\Arch\ToUseQueryAuthentication\ToUseQueryAuthentication')
+        ->toUseQueryAuthentication();
+});

--- a/tests/Feature/ConnectorTest.php
+++ b/tests/Feature/ConnectorTest.php
@@ -6,3 +6,33 @@ it('checks that a connector is a saloon connector', function () {
     expect('Tests\Fixtures\Arch\ToBeSaloonConnector\ToBeSaloonConnector')
         ->toBeSaloonConnector();
 });
+
+it('checks that a connector sets some default headers', function () {
+    expect('Tests\Fixtures\Arch\ToHaveDefaultHeaders\ToBeHaveDefaultHeaders')
+        ->toHaveDefaultHeaders();
+});
+
+it('checks that a connector has a default config', function () {
+    expect('Tests\Fixtures\Arch\ToHaveDefaultConfig\ToBeHaveDefaultConfig')
+        ->toHaveDefaultConfig();
+});
+
+it('checks that a connector has a base url', function () {
+    expect('Tests\Fixtures\Arch\ToBeSaloonConnector\ToBeSaloonConnector')
+        ->toHaveBaseUrl();
+});
+
+it('checks that a connector has a custom response', function () {
+    expect('Tests\Fixtures\Arch\ToUseCustomResponse\ToUseCustomResponse')
+        ->toUseCustomResponse();
+});
+
+it('checks that a connector has custom failure detection', function () {
+    expect('Tests\Fixtures\Arch\ToHaveCustomFailureDetection\ToHaveCustomFailureDetection')
+        ->toHaveCustomFailureDetection();
+});
+
+it('checks that a connector has a custom exception', function () {
+    expect('Tests\Fixtures\Arch\ToHaveCustomException\ToHaveCustomException')
+        ->toHaveCustomException();
+});

--- a/tests/Feature/RequestTest.php
+++ b/tests/Feature/RequestTest.php
@@ -81,3 +81,13 @@ it('checks that a request has a stream body', function () {
     expect('Tests\Fixtures\Arch\ToHaveStreamBody\ToHaveStreamBody')
         ->toHaveStreamBody();
 });
+
+it('checks that a request has a default query', function () {
+    expect('Tests\Fixtures\Arch\ToHaveDefaultQuery\ToHaveDefaultQuery')
+        ->toHaveDefaultQuery();
+});
+
+it('checks that a request has a default body', function () {
+    expect('Tests\Fixtures\Arch\ToHaveDefaultBody\ToHaveDefaultBody')
+        ->toHaveDefaultBody();
+});

--- a/tests/Fixtures/Arch/ToHaveCustomException/ToHaveCustomException.php
+++ b/tests/Fixtures/Arch/ToHaveCustomException/ToHaveCustomException.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToHaveCustomException;
+
+use Saloon\Http\Connector;
+use Saloon\Http\Response;
+use Throwable;
+
+class ToHaveCustomException extends Connector
+{
+    public function getRequestException(Response $response, ?Throwable $senderException): ?Throwable
+    {
+        return new CustomException('Oh yee-naw!', $response, $senderException);
+    }
+
+    public function resolveBaseUrl(): string
+    {
+        return '';
+    }
+}

--- a/tests/Fixtures/Arch/ToHaveCustomFailureDetection/ToHaveCustomFailureDetection.php
+++ b/tests/Fixtures/Arch/ToHaveCustomFailureDetection/ToHaveCustomFailureDetection.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToHaveCustomFailureDetection;
+
+use Saloon\Http\Connector;
+use Saloon\Http\Response;
+
+class ToHaveCustomFailureDetection extends Connector
+{
+    public function hasRequestFailed(Response $response): bool
+    {
+        return true;
+
+    }
+
+    public function resolveBaseUrl(): string
+    {
+        return '';
+    }
+}

--- a/tests/Fixtures/Arch/ToHaveDefaultBody/ToHaveDefaultBody.php
+++ b/tests/Fixtures/Arch/ToHaveDefaultBody/ToHaveDefaultBody.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToHaveDefaultBody;
+
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasStringBody;
+
+class ToHaveDefaultBody extends Request implements HasBody
+{
+    use HasStringBody;
+
+    /**
+     * Define the HTTP method
+     */
+    protected Method $method = Method::POST;
+
+    protected function defaultBody(): string
+    {
+        return '';
+    }
+
+    /**
+     * Define the endpoint for the request
+     */
+    public function resolveEndpoint(): string
+    {
+        return '';
+    }
+}

--- a/tests/Fixtures/Arch/ToHaveDefaultConfig/ToHaveDefaultConfig.php
+++ b/tests/Fixtures/Arch/ToHaveDefaultConfig/ToHaveDefaultConfig.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToHaveDefaultConfig;
+
+use Saloon\Http\Connector;
+
+class ToHaveDefaultConfig extends Connector
+{
+    public function resolveBaseUrl(): string
+    {
+        return '';
+    }
+
+    public function defaultConfig(): array
+    {
+        return [];
+    }
+}

--- a/tests/Fixtures/Arch/ToHaveDefaultHeaders/ToHaveDefaultHeaders.php
+++ b/tests/Fixtures/Arch/ToHaveDefaultHeaders/ToHaveDefaultHeaders.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToHaveDefaultHeaders;
+
+use Saloon\Http\Connector;
+
+class ToHaveDefaultHeaders extends Connector
+{
+    public function resolveBaseUrl(): string
+    {
+        return '';
+    }
+
+    public function defaultHeaders(): array
+    {
+        return [];
+    }
+}

--- a/tests/Fixtures/Arch/ToHaveDefaultQuery/ToHaveDefaultQuery.php
+++ b/tests/Fixtures/Arch/ToHaveDefaultQuery/ToHaveDefaultQuery.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToHaveStreamBody;
+
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasStreamBody;
+
+class ToHaveDefaultQuery extends Request implements HasBody
+{
+    use HasStreamBody;
+
+    /**
+     * Define the HTTP method
+     */
+    protected Method $method = Method::POST;
+
+    protected function defaultQuery(): array
+    {
+        return [];
+    }
+
+    /**
+     * Define the endpoint for the request
+     */
+    public function resolveEndpoint(): string
+    {
+        return '';
+    }
+}

--- a/tests/Fixtures/Arch/ToUseCustomResponse/ToUseCustomResponse.php
+++ b/tests/Fixtures/Arch/ToUseCustomResponse/ToUseCustomResponse.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToUseCustomResponse;
+
+use Saloon\Http\Connector;
+
+class ToUseCustomResponse extends Connector
+{
+    public function resolveResponseClass(): string
+    {
+        return '';
+    }
+
+    public function resolveBaseUrl(): string
+    {
+        return '';
+    }
+}

--- a/tests/Fixtures/Arch/ToUseQueryAuthentication/ToUseQueryAuthentication.php
+++ b/tests/Fixtures/Arch/ToUseQueryAuthentication/ToUseQueryAuthentication.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Arch\ToUseQueryAuthentication;
+
+use Saloon\Http\Auth\QueryAuthenticator;
+use Saloon\Http\Connector;
+
+class ToUseQueryAuthentication extends Connector
+{
+    protected function defaultAuth(): QueryAuthenticator
+    {
+        return new QueryAuthenticator('', '');
+    }
+
+    public function resolveBaseUrl(): string
+    {
+        return '';
+    }
+}


### PR DESCRIPTION
Decided to spend some time ensuring Lawman has everything you need to Arch test your Saloon classes, I thought it did, but it turns out I'm wrong! I started with "The Basics" in the documentation and will probably go through one section per week. This PR adds the following:

- toUseQueryAuthentication
- toHaveDefaultHeaders
- toHaveDefaultConfig
- toHaveBaseUrl
- toUseCustomResponse
- toHaveCustomFailureDetection
- toHaveCustomException
- toHaveDefaultQuery
- toHaveDefaultBody