### PR TITLE
ignore constructor in property expectations

### DIFF
--- a/src/Expectations/Properties.php
+++ b/src/Expectations/Properties.php
@@ -31,7 +31,7 @@ expect()->extend(
     fn (): Expectation => // @phpstan-ignore-next-line
     expect(property_exists($this->value, 'retryInterval'))->toBeTrue()
         ->and((new ReflectionClass($this->value)) // @phpstan-ignore-line
-        ->getProperty('retryInterval')
+            ->getProperty('retryInterval')
             ->getValue((new ReflectionClass($this->value))->newInstanceWithoutConstructor())) // @phpstan-ignore-line
         ->toBeGreaterThan(0)
 );

--- a/src/Expectations/Properties.php
+++ b/src/Expectations/Properties.php
@@ -22,7 +22,7 @@ expect()->extend(
     expect(property_exists($this->value, 'tries'))->toBeTrue()
         ->and((new ReflectionClass($this->value)) // @phpstan-ignore-line
             ->getProperty('tries')
-            ->getValue(new $this->value)) // @phpstan-ignore-line
+            ->getValue((new ReflectionClass($this->value))->newInstanceWithoutConstructor())) // @phpstan-ignore-line
         ->toBeGreaterThan(1)
 );
 
@@ -30,6 +30,10 @@ expect()->extend(
     'toHaveRetryInterval',
     fn (): Expectation => // @phpstan-ignore-next-line
     expect(property_exists($this->value, 'retryInterval'))->toBeTrue()
+        ->and((new ReflectionClass($this->value)) // @phpstan-ignore-line
+        ->getProperty('retryInterval')
+            ->getValue((new ReflectionClass($this->value))->newInstanceWithoutConstructor())) // @phpstan-ignore-line
+        ->toBeGreaterThan(0)
 );
 
 expect()->extend(
@@ -38,7 +42,7 @@ expect()->extend(
     expect(property_exists($this->value, 'useExponentialBackoff'))->toBeTrue()
         ->and((new ReflectionClass($this->value)) // @phpstan-ignore-line
             ->getProperty('useExponentialBackoff')
-            ->getValue(new $this->value)) // @phpstan-ignore-line
+            ->getValue((new ReflectionClass($this->value))->newInstanceWithoutConstructor())) // @phpstan-ignore-line
         ->toBeTrue()
 );
 
@@ -48,6 +52,6 @@ expect()->extend(
     expect(property_exists($this->value, 'throwOnMaxTries'))->toBeTrue()
         ->and((new ReflectionClass($this->value)) // @phpstan-ignore-line
             ->getProperty('throwOnMaxTries')
-            ->getValue(new $this->value)) // @phpstan-ignore-line
+            ->getValue((new ReflectionClass($this->value))->newInstanceWithoutConstructor())) // @phpstan-ignore-line
         ->toBeTrue()
 );

--- a/tests/Fixtures/Arch/ToBeTriedAgainOnFailure/ToBeTriedAgainOnFailure.php
+++ b/tests/Fixtures/Arch/ToBeTriedAgainOnFailure/ToBeTriedAgainOnFailure.php
@@ -11,7 +11,7 @@ class ToBeTriedAgainOnFailure extends Request
 {
     public function __construct(
         public string $test
-    ){}
+    ) {}
 
     /**
      * Define the HTTP method

--- a/tests/Fixtures/Arch/ToBeTriedAgainOnFailure/ToBeTriedAgainOnFailure.php
+++ b/tests/Fixtures/Arch/ToBeTriedAgainOnFailure/ToBeTriedAgainOnFailure.php
@@ -9,6 +9,10 @@ use Saloon\Http\Request;
 
 class ToBeTriedAgainOnFailure extends Request
 {
+    public function __construct(
+        public string $test
+    ){}
+
     /**
      * Define the HTTP method
      */

--- a/tests/Fixtures/Arch/ToHaveRetryInterval/ToHaveRetryInterval.php
+++ b/tests/Fixtures/Arch/ToHaveRetryInterval/ToHaveRetryInterval.php
@@ -11,7 +11,7 @@ class ToHaveRetryInterval extends Request
 {
     public function __construct(
         public string $test
-    ){}
+    ) {}
 
     /**
      * Define the HTTP method

--- a/tests/Fixtures/Arch/ToHaveRetryInterval/ToHaveRetryInterval.php
+++ b/tests/Fixtures/Arch/ToHaveRetryInterval/ToHaveRetryInterval.php
@@ -9,6 +9,10 @@ use Saloon\Http\Request;
 
 class ToHaveRetryInterval extends Request
 {
+    public function __construct(
+        public string $test
+    ){}
+
     /**
      * Define the HTTP method
      */

--- a/tests/Fixtures/Arch/ToThrowOnMaxTries/ToThrowOnMaxTries.php
+++ b/tests/Fixtures/Arch/ToThrowOnMaxTries/ToThrowOnMaxTries.php
@@ -11,7 +11,7 @@ class ToThrowOnMaxTries extends Request
 {
     public function __construct(
         public string $test
-    ){}
+    ) {}
 
     /**
      * Define the HTTP method

--- a/tests/Fixtures/Arch/ToThrowOnMaxTries/ToThrowOnMaxTries.php
+++ b/tests/Fixtures/Arch/ToThrowOnMaxTries/ToThrowOnMaxTries.php
@@ -9,6 +9,10 @@ use Saloon\Http\Request;
 
 class ToThrowOnMaxTries extends Request
 {
+    public function __construct(
+        public string $test
+    ){}
+
     /**
      * Define the HTTP method
      */

--- a/tests/Fixtures/Arch/ToUseExponentialBackoff/ToUseExponentialBackoff.php
+++ b/tests/Fixtures/Arch/ToUseExponentialBackoff/ToUseExponentialBackoff.php
@@ -9,6 +9,10 @@ use Saloon\Http\Request;
 
 class ToUseExponentialBackoff extends Request
 {
+    public function __construct(
+        public string $test
+    ){}
+
     /**
      * Define the HTTP method
      */

--- a/tests/Fixtures/Arch/ToUseExponentialBackoff/ToUseExponentialBackoff.php
+++ b/tests/Fixtures/Arch/ToUseExponentialBackoff/ToUseExponentialBackoff.php
@@ -11,7 +11,7 @@ class ToUseExponentialBackoff extends Request
 {
     public function __construct(
         public string $test
-    ){}
+    ) {}
 
     /**
      * Define the HTTP method


### PR DESCRIPTION
Currently when you use these Expectations:

- ToBeTriedAgainOnFailure
- ToHaveRetryInterval
- ToThrowOnMaxTries
- ToUseExponentialBackoff

It results in an error because it's expecting data to be passed into the `__construct` method. This PR updates those expectations to use `newInstanceWithoutConstructor()` via Reflection, so it bypasses the constructor

Fixes: #8 